### PR TITLE
Changing Permission System to ACE Permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# cookpris - An admin jail script
+An admin command that force players to do a quantity of action until they can leave a jail
+
+- [FiveM Forums](https://forum.cfx.re/t/release-standalone-cookpris-admin-jail/1262887)
+- [Video Preview](https://streamable.com/51mzrg)
+
+## Installation Instructions
+- Download **cookpris** from GitHub
+- **Edit** your **server.cfg** and add ``ensure cookpris`` and ``add_ace group.admin command.jail``
+- Add, remove anything you want, from now on that is your script !

--- a/cookpris/sv_main.lua
+++ b/cookpris/sv_main.lua
@@ -1,46 +1,14 @@
--- Config
 local maxQuantity = 60 -- Maximum quantity of action
-local allowedList =
-{
-	"license:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", -- Add any license over here
-}
-
-
--- Functions
-local function GetRockstarLicense(source)
-	local license = ""
-	for k,v in pairs(GetPlayerIdentifiers(source)) do
-		if string.find(v, "license", 0) ~= nil then
-			license = v
-			return license
-		end
-	end
-end
-
-
 -- Commands
 RegisterCommand('jail', function(source, args)
     if not args[1] or not args[2] then
 		TriggerClientEvent("cookpris:notify", source, "~r~Error :~w~\nThe right command is /jail playerID qty", 3000)
 	else
-		local license = GetRockstarLicense(source)
+		local otherPlayerID = tonumber(args[1])
+		local quantity = tonumber(args[2])
+		if quantity > maxQuantity then quantity = maxQuantity end
 
-		local isAllowed = false
-		for k,v in pairs(allowedList) do
-			if v == license then
-				isAllowed = true
-			end
-		end
-
-		if isAllowed then
-			local otherPlayerID = tonumber(args[1])
-			local quantity = tonumber(args[2])
-			if quantity > maxQuantity then quantity = maxQuantity end
-
-			TriggerClientEvent("cookpris:setInJail", otherPlayerID, quantity)
-			TriggerClientEvent("cookpris:notify", source, "~g~Done :~w~\n" .. GetPlayerName(otherPlayerID) .. " has been sent in jail", 3000)
-		else
-			TriggerClientEvent("cookpris:notify", source, "~r~Error :~w~\nYou doesn't have the permissions", 3000)
-		end
+		TriggerClientEvent("cookpris:setInJail", otherPlayerID, quantity)
+		TriggerClientEvent("cookpris:notify", source, "~g~Done :~w~\n" .. GetPlayerName(otherPlayerID) .. " has been sent in jail", 3000)
 	end
-end, false)
+end, true)


### PR DESCRIPTION
I figured that for most people, using existing ACE Permissions would be more useful than manually putting each staff member into the file. In addition, it should also take less CPU time on the server because it doesn't have to do as much login and only has to pull one value.
In addition, I added a ``README`` file that links back to your FiveM Forums release post, your video preview, and has instructions for installation (modified to fit the ACE system)

- ACE Permission: ``command.jail``

**Things Changed**
- Changed Permission System to ACE based.
- Added a README.md file in the main directory

**NOTE:** If you want to make it so that people can use either version, create a release on GitHub for the current version so that people can download it even after the pull request was merged.

If you have any questions, feel free to message me here or on the [FiveM Forums](https://forum.cfx.re/u/cryoprotectant). 

I made this because I liked the idea that you came up with and through that it would be nice to improve it to use a system that most, if not all, servers are already using.